### PR TITLE
Check to see if there used to be children before diffing

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -18,21 +18,27 @@ function MasonryMixin() {
             diffDomChildren: function() {
                 var oldChildren = this.domChildren;
                 var newChildren = Array.prototype.slice.call(this.refs[reference].getDOMNode().children);
-
-                var removed = oldChildren.filter(function(oldChild) {
-                    return !~newChildren.indexOf(oldChild);
-                });
-
-                var added = newChildren.filter(function(newChild) {
-                    return !~oldChildren.indexOf(newChild);
-                });
-
+                var removed = [];
+                var added = [];
                 var moved = [];
 
-                if (removed.length === 0) {
-                    moved = oldChildren.filter(function(child, index) {
-                        return index !== newChildren.indexOf(child);
+                // Only need to re-diff if there were children before
+                if (oldChildren.length > 0) {
+                    removed = oldChildren.filter(function(oldChild) {
+                        return !~newChildren.indexOf(oldChild);
                     });
+
+                    added = newChildren.filter(function(newChild) {
+                        return !~oldChildren.indexOf(newChild);
+                    });
+
+                    moved = [];
+
+                    if (removed.length === 0) {
+                        moved = oldChildren.filter(function(child, index) {
+                            return index !== newChildren.indexOf(child);
+                        });
+                    }
                 }
 
                 this.domChildren = newChildren;


### PR DESCRIPTION
I was having a problem in my application where, when navigating from one page to another, the mixin would double-count elements when diffing. This resulted in all elements starting `n` pixels from the left, where `n = width of elements * num of elements double-counted`. 

This PR defaults `removed`, `added`, and `moved` to empty arrays and only does the diffing logic of the number of `oldChildren` is greater than 0