### PR TITLE
added initial dom nodes on init. fixes server side rendering

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -12,12 +12,20 @@ function MasonryMixin() {
             initializeMasonry: function(force) {
                 if (!this.masonry || force) {
                     this.masonry = new Masonry(this.refs[reference].getDOMNode(), options);
+                    this.domChildren = this.getNewDomChildren();
                 }
+            },
+
+            getNewDomChildren: function () {
+                var node = this.refs[reference].getDOMNode();
+                var children = options.itemSelector ? node.querySelectorAll(options.itemSelector) : node.children;
+                
+                return Array.prototype.slice.call(children);
             },
 
             diffDomChildren: function() {
                 var oldChildren = this.domChildren;
-                var newChildren = Array.prototype.slice.call(this.refs[reference].getDOMNode().children);
+                var newChildren = this.getNewDomChildren();
 
                 var removed = oldChildren.filter(function(oldChild) {
                     return !~newChildren.indexOf(oldChild);


### PR DESCRIPTION
Hey,
I've noticed that the `componentDidMount` method starts a new diff of the DOM and finds all new child elements within the container, afterwards the items will be added to masonry. This works well unless the container has child elements (default & client-side only). Initial child elements (server-side) were picked up by masonry on initialisation and __readded__ by the first `componentDidMount` call – which is now a thing of the past.

I've also included a check for masonrys optional [itemSelector](http://masonry.desandro.com/options.html#itemselector) option but didn't include further element-options like [gutter](http://masonry.desandro.com/options.html#gutter) and [columnwidth](http://masonry.desandro.com/options.html#columnwidth).
Cheers