### PR TITLE
Clear timeout when unmounting component

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -19,7 +19,7 @@ function MasonryMixin() {
             getNewDomChildren: function () {
                 var node = this.refs[reference].getDOMNode();
                 var children = options.itemSelector ? node.querySelectorAll(options.itemSelector) : node.children;
-                
+
                 return Array.prototype.slice.call(children);
             },
 
@@ -95,10 +95,14 @@ function MasonryMixin() {
             },
 
             componentWillReceiveProps: function() {
-                setTimeout(function() {
+                this._timer = setTimeout(function() {
                     this.masonry.reloadItems();
                     this.forceUpdate();
                 }.bind(this), 0);
+            },
+
+            componentWillUnmount: function() {
+                clearTimeout(this._timer);
             }
         };
     };


### PR DESCRIPTION
I have an issue where my components are re-rendering in the same VM stack frame that they are unmounted. It causes the following warning in the console:

    Warning: forceUpdate(...): Can only update a mounted or mounting
    component. This usually means you called forceUpdate() on an unmounted
    component. This is a no-op.

Although it's not exactly the best thing to have my components re-render in this spot, the mixin should still clear its timers when it unmounts. I'm submitting my proposed patch although I'm still rather unfamiliar with React mixins.