### PR TITLE
Bugfix: masonry tried to remove unattached elements from DOM

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -24,7 +24,10 @@ function MasonryMixin() {
             },
 
             diffDomChildren: function() {
-                var oldChildren = this.domChildren;
+                var oldChildren = this.domChildren.filter(function(element) {
+                    // take only elements attached to DOM (aka the parent is the masonry container, not null)
+                    return element.parentNode;
+                });
                 var newChildren = this.getNewDomChildren();
 
                 var removed = oldChildren.filter(function(oldChild) {


### PR DESCRIPTION
In some cases React removes the elements from the DOM before masonry can do so, yielding an ugly error ("Cannot call method 'removeChild' of null"). Needed an extra-check to prevent that, based on the safe assumption that an element's parentNode is in either null or the masonry container