### PR TITLE
to support IE8

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ var masonryOptions = {
  
 var SomeComponent = React.createClass({
 
-    mixins: [MasonryMixin('masonryContainer', masonryOptions)],
+    mixins: [MasonryMixin(React)('masonryContainer', masonryOptions)],
  
     render: function () {
         var childElements = this.props.elements.map(function(element){

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,6 +3,16 @@ var Masonry = isBrowser ? window.Masonry || require('masonry') : null;
 var imagesloaded = isBrowser ? require('imagesloaded') : null;
 var nullNode = { getDOMNode: function() { return null; } };
 
+// can not use Array.prototype.slice.call(nodelist) to get a array in IE8
+// http://stackoverflow.com/questions/2735067/how-to-convert-a-dom-node-list-to-an-array-in-javascript
+function nodeListToArray(nodelist) {
+	var array = [];
+	for (var i = 0, len = nodelist.length; i < len; i++) {
+		array[i] = nodelist[i];
+	}
+	return array;
+}
+
 function MasonryMixin(React) {
     return function(reference, options) {
 
@@ -36,7 +46,7 @@ function MasonryMixin(React) {
             getNewDomChildren: function() {
                 var node = React.findDOMNode ? React.findDOMNode(this.refs[reference]) : (this.refs[reference] || nullNode).getDOMNode();
                 var children = options.itemSelector ? node.querySelectorAll(options.itemSelector) : node.children;
-                return Array.prototype.slice.call(children);
+                return nodeListToArray(children);
             },
 
             diffDomChildren: function() {


### PR DESCRIPTION
Array.prototype.slice.call(nodelist) can not work on IE8:
<http://stackoverflow.com/questions/2735067/how-to-convert-a-dom-node-list-to-an-array-in-javascript>